### PR TITLE
Decode the JSON request response from bytes to str

### DIFF
--- a/pyJeedom.py
+++ b/pyJeedom.py
@@ -617,7 +617,7 @@ class jeedom():
 		url = self.adrss + quoteurl(data)
 		response = requestUrl.urlopen(url).read()
 		try:
-			result = json.loads(response)
+			result = json.loads(response.decode())
 			if 'error' in result: return result
 			return result['result']
 		except Exception as e:


### PR DESCRIPTION
The python3 type returned from requestUrl.urlopen(url).read() is 'bytes'.
json.loads() expects a 'str' type, otherwise, a TypeError is raised